### PR TITLE
Metadata update

### DIFF
--- a/folderTypes.cfg
+++ b/folderTypes.cfg
@@ -7,7 +7,6 @@ Day:
         species: "list", ['mouse', 'human']
         time_of_dissection: "string"
         target_region: "list", ['', 'V1', 'ALM']
-        hemisphere: "list", ['', 'left', 'right']
         temperature: "list", ['32C', '34C', '25C', '37C', 'RT']
         solution: "list", ["Standard", "ACSF III (no blockers)", "2mM Ca & Mg", "1.3mM Ca & 1mM Mg"]
         solution_pH: 'string'
@@ -17,7 +16,6 @@ Slice:
     name: "slice"
     info:
         slice quality: "list", ["1", "2", "3", "4", "5"]
-        surface: "list", ['medial', 'lateral']
         specimen_ID: "string"
         carousel_well_ID: "string"
         plate_well_ID: "string"

--- a/folderTypes.cfg
+++ b/folderTypes.cfg
@@ -4,13 +4,11 @@ Day:
     info:
         description: "text", 6
         animal_ID: "string"
-        
-        species: "list", ["Sim1-Cre_KJ18;AI14", "Tlx3-Cre_PL56;AI14", "Sst-IERS-Cre;Ai14", "Pvalb-IRES-Cre; Ai14", "Pvalb-IRES-Cre;Ai140; Rorb-2A-tTA2;Ai63", "Tlx3-Cre_PL56;Ai140; Pvalb-2A-FlpO;Ai65F", "Ctgf-2A-dgCre;Ai14", "Vip-IRES-Cre;Ai140;Pvalb-2A-FlpO;Ai65F", "Sst-IRES-Cre;Ai140;Pvalb-2A-FlpO;Ai65F", "Tlx3-Cre_PL56;Ai140;Sst-IRES-FlpO:Ai65F", "Sim1-Cre_KJ18;Ai140;Sst-IRES-FlpO;Ai65F", "Sim1-Cre_KJ18;Ai140;Pvalb-2A-FlpO;Ai65F", "Vip-IRES-Cre;Ai140;Sst-IRES-FlpO;Ai65", "Chat-IRES-Cre-neo;Snap25-LSL-F2A-GFP", "Slc17ae-IRES2-Cre;AI14"]
-
-        age: "string"
-        sex: "list", ['M', 'F']
-        weight: "string"
-        temperature: "list", ['34C', '32C', '25C', '37C', 'RT']
+        species: "list", ['mouse', 'human']
+        time_of_dissection: "string"
+        target_region: "list", ['', 'V1', 'ALM']
+        hemisphere: "list", ['', 'left', 'right']
+        temperature: "list", ['32C', '34C', '25C', '37C', 'RT']
         solution: "list", ["Standard", "ACSF III (no blockers)", "2mM Ca & Mg", "1.3mM Ca & 1mM Mg"]
         solution_pH: 'string'
         solution_osm: 'string'
@@ -19,8 +17,7 @@ Slice:
     name: "slice"
     info:
         slice quality: "list", ["1", "2", "3", "4", "5"]
-        location: "string"
-        orientation: "string"
+        surface: "list", ['medial', 'lateral']
         specimen_ID: "string"
         carousel_well_ID: "string"
         plate_well_ID: "string"

--- a/folderTypes.cfg
+++ b/folderTypes.cfg
@@ -4,7 +4,6 @@ Day:
     info:
         description: "text", 6
         animal_ID: "string"
-        species: "list", ['mouse', 'human']
         time_of_dissection: "string"
         target_region: "list", ['', 'V1', 'ALM']
         temperature: "list", ['32C', '34C', '25C', '37C', 'RT']

--- a/folderTypes.cfg
+++ b/folderTypes.cfg
@@ -36,10 +36,4 @@ Site:
         Headstage 7: "list", ["GS", "LS", "NS", "TF", "NA"]
         Headstage 8: "list", ["GS", "LS", "NS", "TF", "NA"]
         notes: "text", 4
-Cell:
-    name: "cell"
-    info:
-        location: "string"
-        type: "list", ['unknown', 'bushy', 'stellate', 'pyramidal', 'fast spiking', 'globular bushy', 'spherical bushy', 'D-stellate', 'T-stellate',  'tuberculoventral', 'cartwheel', 'octopus']
-        depth: "string"
-        notes: "text", 10
+


### PR DESCRIPTION
* species is now human or mouse; there is no place to enter the cre type information (this will be fetched from LIMS instead)
* likewise, age/sex/weight are removed
* added time_of_dissection, which should be filled in from the specimen ID stickers 
* added target_region and hemisphere fields
* replaced site location and orientation fields with `surface` (but do we need this?)